### PR TITLE
Extra attributes bugfix

### DIFF
--- a/src/Internal/FallbackAttributeReader.php
+++ b/src/Internal/FallbackAttributeReader.php
@@ -203,9 +203,12 @@ final class FallbackAttributeReader extends AttributeReader
          *  $ast->getEndLine(); // 2 (last significant character of a function)
          * </code>
          */
-        $result = $attributes[$line - 1] ?? null;
-        if ($result !== null && $function->isClosure()) {
-            return $result;
+        if ($function->isClosure()) {
+            while ($line-- > $function->getStartLine()) {
+                if ($result = $attributes[$line] ?? null) {
+                    return $result;
+                }
+            }
         }
 
         return [];

--- a/src/Internal/FallbackAttributeReader.php
+++ b/src/Internal/FallbackAttributeReader.php
@@ -203,10 +203,9 @@ final class FallbackAttributeReader extends AttributeReader
          *  $ast->getEndLine(); // 2 (last significant character of a function)
          * </code>
          */
-        while ($line-- > 0) {
-            if ($result = $attributes[$line] ?? null) {
-                return $result;
-            }
+        $result = $attributes[$line - 1] ?? null;
+        if ($result !== null && $function->isClosure()) {
+            return $result;
         }
 
         return [];

--- a/src/Internal/Instantiator/NamedArgumentsInstantiator.php
+++ b/src/Internal/Instantiator/NamedArgumentsInstantiator.php
@@ -14,7 +14,7 @@ namespace Spiral\Attributes\Internal\Instantiator;
 use Spiral\Attributes\Internal\Exception;
 
 /**
- * @internal NamedArgumentsInstantiator is an internal library class, please do not use it in your code.
+ * @internal       NamedArgumentsInstantiator is an internal library class, please do not use it in your code.
  * @psalm-internal Spiral\Attributes
  */
 final class NamedArgumentsInstantiator extends Instantiator
@@ -31,8 +31,8 @@ final class NamedArgumentsInstantiator extends Instantiator
 
     /**
      * @param \ReflectionClass $attr
-     * @param array $arguments
-     * @param string $context
+     * @param array            $arguments
+     * @param string           $context
      * @return object
      * @throws \Throwable
      */
@@ -66,9 +66,9 @@ final class NamedArgumentsInstantiator extends Instantiator
     }
 
     /**
-     * @param \ReflectionClass $ctx
+     * @param \ReflectionClass  $ctx
      * @param \ReflectionMethod $constructor
-     * @param array $arguments
+     * @param array             $arguments
      * @return array
      * @throws \Throwable
      */
@@ -93,9 +93,9 @@ final class NamedArgumentsInstantiator extends Instantiator
     }
 
     /**
-     * @param \ReflectionClass $ctx
+     * @param \ReflectionClass     $ctx
      * @param \ReflectionParameter $param
-     * @param array $arguments
+     * @param array                $arguments
      * @return mixed
      * @throws \Throwable
      */
@@ -103,18 +103,14 @@ final class NamedArgumentsInstantiator extends Instantiator
     {
         switch (true) {
             case \array_key_exists($param->getName(), $arguments):
-                try {
-                    return $arguments[$param->getName()];
-                } finally {
-                    unset($arguments[$param->getName()]);
-                }
+                $argument =  $arguments[$param->getName()];
+                unset($arguments[$param->getName()]);
+                return $argument;
 
             case \array_key_exists($param->getPosition(), $arguments):
-                try {
-                    return $arguments[$param->getPosition()];
-                } finally {
-                    unset($arguments[$param->getPosition()]);
-                }
+                $argument =  $arguments[$param->getPosition()];
+                unset($arguments[$param->getPosition()]);
+                return $argument;
 
             case $param->isDefaultValueAvailable():
                 return $param->getDefaultValue();

--- a/src/Internal/Instantiator/NamedArgumentsInstantiator.php
+++ b/src/Internal/Instantiator/NamedArgumentsInstantiator.php
@@ -14,7 +14,7 @@ namespace Spiral\Attributes\Internal\Instantiator;
 use Spiral\Attributes\Internal\Exception;
 
 /**
- * @internal       NamedArgumentsInstantiator is an internal library class, please do not use it in your code.
+ * @internal NamedArgumentsInstantiator is an internal library class, please do not use it in your code.
  * @psalm-internal Spiral\Attributes
  */
 final class NamedArgumentsInstantiator extends Instantiator
@@ -31,8 +31,8 @@ final class NamedArgumentsInstantiator extends Instantiator
 
     /**
      * @param \ReflectionClass $attr
-     * @param array            $arguments
-     * @param string           $context
+     * @param array $arguments
+     * @param string $context
      * @return object
      * @throws \Throwable
      */
@@ -66,9 +66,9 @@ final class NamedArgumentsInstantiator extends Instantiator
     }
 
     /**
-     * @param \ReflectionClass  $ctx
+     * @param \ReflectionClass $ctx
      * @param \ReflectionMethod $constructor
-     * @param array             $arguments
+     * @param array $arguments
      * @return array
      * @throws \Throwable
      */
@@ -93,9 +93,9 @@ final class NamedArgumentsInstantiator extends Instantiator
     }
 
     /**
-     * @param \ReflectionClass     $ctx
+     * @param \ReflectionClass $ctx
      * @param \ReflectionParameter $param
-     * @param array                $arguments
+     * @param array $arguments
      * @return mixed
      * @throws \Throwable
      */

--- a/src/Internal/Instantiator/NamedArgumentsInstantiator.php
+++ b/src/Internal/Instantiator/NamedArgumentsInstantiator.php
@@ -103,14 +103,18 @@ final class NamedArgumentsInstantiator extends Instantiator
     {
         switch (true) {
             case \array_key_exists($param->getName(), $arguments):
-                $argument =  $arguments[$param->getName()];
-                unset($arguments[$param->getName()]);
-                return $argument;
+                try {
+                    return $arguments[$param->getName()];
+                } finally {
+                    unset($arguments[$param->getName()]);
+                }
 
             case \array_key_exists($param->getPosition(), $arguments):
-                $argument =  $arguments[$param->getPosition()];
-                unset($arguments[$param->getPosition()]);
-                return $argument;
+                try {
+                    return $arguments[$param->getPosition()];
+                } finally {
+                    unset($arguments[$param->getPosition()]);
+                }
 
             case $param->isDefaultValueAvailable():
                 return $param->getDefaultValue();

--- a/src/Internal/Instantiator/NamedArgumentsInstantiator.php
+++ b/src/Internal/Instantiator/NamedArgumentsInstantiator.php
@@ -108,6 +108,7 @@ final class NamedArgumentsInstantiator extends Instantiator
                 } finally {
                     unset($arguments[$param->getName()]);
                 }
+            // no actual falling through
 
             case \array_key_exists($param->getPosition(), $arguments):
                 try {
@@ -115,6 +116,7 @@ final class NamedArgumentsInstantiator extends Instantiator
                 } finally {
                     unset($arguments[$param->getPosition()]);
                 }
+            // no actual falling through
 
             case $param->isDefaultValueAvailable():
                 return $param->getDefaultValue();


### PR DESCRIPTION
Extra attributes bugfix

## Example

```php
class Test {
    #[ExampleAttribute]
    public function a(): string {}

    public function b(){}
}

///

$reader = new AttributeReader();

foreach ((new \ReflectionClass(Test::class))->getMethods() as $method) {
    foreach ($reader->getFunctionMetadata($method) as $attr) {
        dump($method->getName(), $attr);
    }
}
```

## Actual

```php
"a"
ExampleAttribute {#662
  +name: null
}

"b"
ExampleAttribute {#663
  +name: null
}
```

## Expected

```php
"a"
ExampleAttribute {#662
  +name: null
}
```