### PR TITLE
Deprecate annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,8 @@
     "require-dev": {
         "doctrine/annotations": "^1.12 || ^2.0",
         "jetbrains/phpstorm-attributes": "^1.0",
-        "symfony/var-dumper": "^5.2 || ^6.0",
         "phpunit/phpunit": "^9.5.20",
-        "vimeo/psalm": "^4.21"
+        "vimeo/psalm": "^5.17"
     },
     "autoload": {
         "files": [
@@ -50,7 +49,7 @@
         ]
     },
     "suggest": {
-        "doctrine/annotations": "^1.0 for Doctrine metadata driver support"
+        "doctrine/annotations": "^1.0 || ^2.0 for Doctrine metadata driver support"
     },
     "config": {
         "sort-packages": true

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
 >
     <projectFiles>
         <directory name="src" />

--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -8,6 +8,9 @@ use Doctrine\Common\Annotations\Reader;
 use Spiral\Attributes\Internal\Decorator;
 use Spiral\Attributes\Internal\DoctrineAnnotationReader;
 
+/**
+ * @deprecated Use {@see AttributeReader} instead.
+ */
 final class AnnotationReader extends Decorator
 {
     public function __construct(Reader $reader = null)

--- a/src/Bridge/DoctrineReaderBridge.php
+++ b/src/Bridge/DoctrineReaderBridge.php
@@ -27,6 +27,7 @@ use Spiral\Attributes\ReaderInterface;
  *  //
  *  $doctrine = new \Doctrine\Common\Annotations\CachedReader($bridge, $cache);
  * </code>
+ * @deprecated
  */
 final class DoctrineReaderBridge implements Reader
 {

--- a/src/Exception/InitializationException.php
+++ b/src/Exception/InitializationException.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Attributes\Exception;
 
+/**
+ * @deprecated
+ */
 class InitializationException extends AttributeException
 {
 }

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Attributes\Exception;
 
+/**
+ * @deprecated
+ */
 class NotFoundException extends AttributeException
 {
 }

--- a/src/Exception/SyntaxAttributeException.php
+++ b/src/Exception/SyntaxAttributeException.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Attributes\Exception;
 
+/**
+ * @deprecated
+ */
 class SyntaxAttributeException extends AttributeException
 {
 }

--- a/src/Internal/DoctrineAnnotationReader.php
+++ b/src/Internal/DoctrineAnnotationReader.php
@@ -13,6 +13,9 @@ use Spiral\Attributes\Exception\SemanticAttributeException;
 use Spiral\Attributes\Exception\SyntaxAttributeException;
 use Spiral\Attributes\Reader as BaseReader;
 
+/**
+ * @deprecated
+ */
 final class DoctrineAnnotationReader extends BaseReader
 {
     private Reader $reader;

--- a/src/Internal/Instantiator/DoctrineInstantiator.php
+++ b/src/Internal/Instantiator/DoctrineInstantiator.php
@@ -12,6 +12,7 @@ use Spiral\Attributes\Exception\SyntaxAttributeException;
 /**
  * @internal DoctrineInstantiator is an internal library class, please do not use it in your code.
  * @psalm-internal Spiral\Attributes
+ * @deprecated Use {@see NamedArgumentsInstantiator} instead.
  */
 final class DoctrineInstantiator extends Instantiator
 {

--- a/src/NamedArgumentConstructor.php
+++ b/src/NamedArgumentConstructor.php
@@ -25,6 +25,7 @@ if (!\class_exists(DoctrineNamedArgumentConstructor::class, false)) {
  *
  * @Annotation
  * @Target({ "CLASS" })
+ * @deprecated
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class NamedArgumentConstructor extends DoctrineNamedArgumentConstructor

--- a/src/NamedArgumentConstructorAttribute.php
+++ b/src/NamedArgumentConstructorAttribute.php
@@ -21,6 +21,7 @@ if (!\class_exists(NamedArgumentConstructorAnnotation::class, false)) {
 /**
  * Marker interface for PHP7/PHP8 compatible support for named arguments
  * (and constructor property promotion).
+ * @deprecated
  */
 interface NamedArgumentConstructorAttribute extends NamedArgumentConstructorAnnotation
 {


### PR DESCRIPTION
## What was changed

All classes that work with annotations using the **doctrine/annotations** package are declared deprecated. Instead of annotations, PHP 8 attributes should be used. The **Spiral\Attributes\NamedArgumentConstructor** attribute is declared deprecated, but for backward compatibility, the behavior is preserved and the attribute is used. If you want to stop using it now, you need to use **Spiral\Attributes\AttributeReader** and explicitly pass **Spiral\Attributes\Internal\Instantiator\NamedArgumentsInstantiator** to its constructor.

```php
$reader = new AttributeReader(new NamedArgumentsInstantiator());
```

And removed unused dependency **symfony/var-dumper**.