### PR TITLE
AnnotationReader: ignore `note`, `mixin`, `yield`

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -9,7 +9,6 @@ enabled:
   - linebreak_after_opening_tag
   - single_quote
   - no_blank_lines_after_phpdoc
-  - unary_operator_spaces
   - no_useless_else
   - no_useless_return
   - trailing_comma_in_multiline_array

--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -15,6 +15,10 @@ final class AnnotationReader extends Decorator
 {
     public function __construct(Reader $reader = null)
     {
+        AnnotationReader::addGlobalIgnoredName('mixin');
+        AnnotationReader::addGlobalIgnoredName('yield');
+        AnnotationReader::addGlobalIgnoredName('note');
+
         parent::__construct(new DoctrineAnnotationReader($reader));
     }
 }

--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -15,10 +15,6 @@ final class AnnotationReader extends Decorator
 {
     public function __construct(Reader $reader = null)
     {
-        AnnotationReader::addGlobalIgnoredName('mixin');
-        AnnotationReader::addGlobalIgnoredName('yield');
-        AnnotationReader::addGlobalIgnoredName('note');
-
         parent::__construct(new DoctrineAnnotationReader($reader));
     }
 }

--- a/src/Internal/DoctrineAnnotationReader.php
+++ b/src/Internal/DoctrineAnnotationReader.php
@@ -24,6 +24,10 @@ final class DoctrineAnnotationReader extends BaseReader
     {
         $this->checkAvailability();
 
+        DoctrineReader::addGlobalIgnoredName('mixin');
+        DoctrineReader::addGlobalIgnoredName('yield');
+        DoctrineReader::addGlobalIgnoredName('note');
+
         $this->reader = $reader ?? new DoctrineReader();
     }
 

--- a/tests/Reader/DoctrineReaderTestCase.php
+++ b/tests/Reader/DoctrineReaderTestCase.php
@@ -13,6 +13,8 @@ namespace Spiral\Tests\Attributes\Reader;
 
 use Spiral\Attributes\AnnotationReader;
 use Spiral\Attributes\ReaderInterface;
+use Spiral\Tests\Attributes\Reader\Fixture\Annotation\ClassAnnotation;
+use Spiral\Tests\Attributes\Reader\Fixture\ClassWithIgnoredAnnotations;
 
 /**
  * Doctrine reader does not support:
@@ -34,5 +36,17 @@ class DoctrineReaderTestCase extends ReaderTestCase
     protected function getReader(): ReaderInterface
     {
         return new AnnotationReader();
+    }
+
+    public function testIgnoredAnnotations(): void
+    {
+        $reader = $this->getReader();
+
+        $this->assertEquals(
+            [new ClassAnnotation()],
+            $this->iterableToArray($reader->getClassMetadata(
+                $this->getReflectionClass(ClassWithIgnoredAnnotations::class)
+            ))
+        );
     }
 }

--- a/tests/Reader/Fixture/ClassWithIgnoredAnnotations.php
+++ b/tests/Reader/Fixture/ClassWithIgnoredAnnotations.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Attributes\Reader\Fixture;
+
+use Spiral\Tests\Attributes\Reader\Fixture\Annotation\ClassAnnotation;
+
+/**
+ * @mixin
+ * @yield
+ * @note
+ * @ClassAnnotation
+ */
+class ClassWithIgnoredAnnotations
+{
+}


### PR DESCRIPTION
Closes https://github.com/spiral/attributes/issues/6