### PR TITLE
Add `type` annotation into ignore list

### DIFF
--- a/src/Internal/DoctrineAnnotationReader.php
+++ b/src/Internal/DoctrineAnnotationReader.php
@@ -27,6 +27,7 @@ final class DoctrineAnnotationReader extends BaseReader
         DoctrineReader::addGlobalIgnoredName('mixin');
         DoctrineReader::addGlobalIgnoredName('yield');
         DoctrineReader::addGlobalIgnoredName('note');
+        DoctrineReader::addGlobalIgnoredName('type');
 
         $this->reader = $reader ?? new DoctrineReader();
     }

--- a/tests/Reader/Fixture/ClassWithIgnoredAnnotations.php
+++ b/tests/Reader/Fixture/ClassWithIgnoredAnnotations.php
@@ -10,6 +10,7 @@ use Spiral\Tests\Attributes\Reader\Fixture\Annotation\ClassAnnotation;
  * @mixin
  * @yield
  * @note
+ * @type
  * @ClassAnnotation
  */
 class ClassWithIgnoredAnnotations


### PR DESCRIPTION
Fixes annotations scanning when Symfony validator is used with protobuf generated files
![image](https://github.com/spiral/attributes/assets/4152481/6c9c5cf8-8006-48e9-9fb2-bcca82f87100)
